### PR TITLE
Access token docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Line of Business Accelerator
 
 [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjwendl%2Flob-application-accelerator%2Fmaster%2Ftemplate%2FLobAccelerator.Template%2Fazuredeploy.json)
+
+## Prerequisites
+- [Get an access token](docs/access_tokens.md)

--- a/docs/access_tokens.md
+++ b/docs/access_tokens.md
@@ -1,0 +1,9 @@
+# Access Tokens
+
+The accelerator assumes that you have an AAD access token with proper permissions to provision the required O365 resources. You can retrieve an access token by following steps 1-3 on the Microsoft Graph docs for [Getting access on behalf of a user](https://developer.microsoft.com/en-us/graph/docs/concepts/auth_v2_user).
+
+In step 1, when registering your app, add the following delegated permissions in the Microsoft Graph Permissions section:
+- `Group.ReadWrite.All` (for Teams)
+- `Sites.ReadWrite.All` (for SharePoint)
+
+In steps 2-3, include these scopes in the scope parameters. For example: `scope=offline_access group.readwrite.all sites.readwrite.all`


### PR DESCRIPTION
The official Graph docs for getting access tokens seems sufficient, so this points to the official doc with some additional notes specific to the accelerator.