### PR TITLE
#83 The X-TMScopes scopes were being added from both TeamsManager and…

### DIFF
--- a/src/LobAccelerator.App/Locators/ServiceLocator.cs
+++ b/src/LobAccelerator.App/Locators/ServiceLocator.cs
@@ -30,6 +30,12 @@ namespace LobAccelerator.App.Locators
                 {
                     BaseAddress = new Uri(sp.GetRequiredService<IConfiguration>()["GraphBaseUri"])
                 };
+                var desiredScopes = new string[]
+                {
+                "Group.ReadWrite.All",
+                "User.ReadBasic.All"
+                };
+                httpClient.DefaultRequestHeaders.Add("X-LOBScopes", desiredScopes);
 
                 return httpClient;
             });

--- a/src/LobAccelerator.Library.Tests/SharepointTests.cs
+++ b/src/LobAccelerator.Library.Tests/SharepointTests.cs
@@ -22,7 +22,6 @@ namespace LobAccelerator.Library.Tests
             var configuration = new ConfigurationManager();
             var tokenRetriever = new TokenRetriever(configuration);
             var tokenManager = new TokenManager(configuration);
-            var sharepointManager = new SharePointManager(configuration, tokenManager);
             var scopes = new string[] {
                 $"api://{configuration["ClientId"]}/access_as_user"
             };
@@ -41,8 +40,7 @@ namespace LobAccelerator.Library.Tests
             var uri = await tokenManager.GetAuthUriAsync(scopes);
             var authCode = await tokenRetriever.GetAuthCodeByMsalUriAsync(uri);
             var authResult = await tokenManager.GetAccessTokenFromCodeAsync(authCode, scopes);
-
-            tokenManager.UpdateAccessToken(authResult.AccessToken);
+            var sharepointManager = new SharePointManager(configuration, tokenManager, authResult.AccessToken);
             var result = await sharepointManager.CreateSiteCollectionAsync(siteCollection);
 
             //Assert

--- a/src/LobAccelerator.Library.Tests/TeamsTests.cs
+++ b/src/LobAccelerator.Library.Tests/TeamsTests.cs
@@ -238,13 +238,13 @@ namespace LobAccelerator.Library.Tests
             var authResult = await tokenManager.GetAccessTokenFromCodeAsync(authCode, scopes);
             var tokenManagerHttpMessageHandler = new TokenManagerHttpMessageHandler(tokenManager, authResult.AccessToken);
             var httpClient = new HttpClient(tokenManagerHttpMessageHandler);
-            httpClient.BaseAddress = new Uri(configurationManager["AzureAD:GraphBaseUri"]);
+            httpClient.BaseAddress = new Uri(configurationManager["GraphBaseUri"]);
             var desiredScopes = new string[]
             {
                 "Group.ReadWrite.All",
                 "User.ReadBasic.All"
             };
-            httpClient.DefaultRequestHeaders.Add("X-TMScopes", desiredScopes);
+            httpClient.DefaultRequestHeaders.Add("X-LOBScopes", desiredScopes);
             return httpClient;
         }
     }

--- a/src/LobAccelerator.Library.Tests/TokenTests.cs
+++ b/src/LobAccelerator.Library.Tests/TokenTests.cs
@@ -27,32 +27,12 @@ namespace LobAccelerator.Library.Tests
             scopes = new string[] {
                 "Group.ReadWrite.All",
             };
-            var onBehalfOfResult = await tokenManager.GetOnBehalfOfAccessTokenAsync(scopes,
-                authResult.AccessToken);
+            var onBehalfOfResult = await tokenManager.GetOnBehalfOfAccessTokenAsync(
+                authResult.AccessToken,
+                scopes);
 
             //Assert
             Assert.NotNull(onBehalfOfResult);
-        }
-
-
-        [Fact]
-        public async Task ValidateAccessToken()
-        {
-            //Arrange
-            var configuration = new ConfigurationManager();
-            var tokenRetriever = new TokenRetriever(configuration);
-            var scopes = new string[] { "Group.ReadWrite.All",
-                $"api://{configuration["ClientId"]}/access_as_user" };
-            var expectedAudience = configuration["ExpectedAudience"];
-            var expectedIssuer = configuration["ExpectedIssuer"];
-
-            //Act
-            var token = await tokenRetriever.GetTokenByAuthorizationCodeFlowAsync(scopes);
-            //var validation = await AuthHelper.ValidateTokenAsync(token.access_token, expectedIssuer, expectedAudience, scopes);
-
-            //Assert
-            // We will only validate the On-behalf-of tokens...
-            //Assert.NotNull(validation);
         }
     }
 }

--- a/src/LobAccelerator.Library/Managers/OneDriveManager.cs
+++ b/src/LobAccelerator.Library/Managers/OneDriveManager.cs
@@ -14,13 +14,6 @@ namespace LobAccelerator.Library.Managers
         public OneDriveManager(HttpClient httpClient)
         {
             this.httpClient = httpClient;
-
-            var desiredScopes = new string[]
-            {
-                "Group.ReadWrite.All",
-                "User.ReadBasic.All"
-            };
-            this.httpClient.DefaultRequestHeaders.Add("X-TMScopes", desiredScopes);
         }
 
         public async Task CopyFileFromOneDriveToTeams(string teamId, string teamChannel, string originOnedrivePath)

--- a/src/LobAccelerator.Library/Managers/SharepointManager.cs
+++ b/src/LobAccelerator.Library/Managers/SharepointManager.cs
@@ -15,11 +15,13 @@ namespace LobAccelerator.Library.Managers
     {
         private readonly IConfiguration configuration;
         private readonly ITokenManager tokenManager;
+        private readonly string accessToken;
 
-        public SharePointManager(IConfiguration configuration, ITokenManager tokenManager)
+        public SharePointManager(IConfiguration configuration, ITokenManager tokenManager, string accessToken)
         {
             this.configuration = configuration;
             this.tokenManager = tokenManager;
+            this.accessToken = accessToken;
         }
 
         public async Task<Result<SiteCollection>> CreateSiteCollectionAsync(SiteCollection siteCollection)
@@ -45,6 +47,7 @@ namespace LobAccelerator.Library.Managers
                 var op = tenant.CreateSite(properties);
                 context.Load(tenant);
                 context.Load(op, i => i.IsComplete);
+                // TODO: Fails with 400 Bad Request
                 context.ExecuteQuery();
 
                 result.Value = siteCollection;
@@ -62,7 +65,7 @@ namespace LobAccelerator.Library.Managers
             {
                 $"https://{configuration["SharePointTenantPrefix"]}.sharepoint.com/AllSites.FullControl"
             };
-            var authResult = await tokenManager.GetOnBehalfOfAccessTokenAsync(desiredScopes);
+            var authResult = await tokenManager.GetOnBehalfOfAccessTokenAsync(this.accessToken, desiredScopes);
             e.WebRequestExecutor.RequestHeaders.Add("Authorization", $"Bearer ${authResult.AccessToken}");
         }
     }

--- a/src/LobAccelerator.Library/Managers/TeamsManager.cs
+++ b/src/LobAccelerator.Library/Managers/TeamsManager.cs
@@ -32,13 +32,6 @@ namespace LobAccelerator.Library.Managers
             this.httpClient = httpClient;
             this.logger = logger;
 
-            var desiredScopes = new string[]
-            {
-                "Group.ReadWrite.All",
-                "User.ReadBasic.All"
-            };
-            this.httpClient.DefaultRequestHeaders.Add("X-TMScopes", desiredScopes);
-
             _baseUri = new Uri("https://graph.microsoft.com/");
             _apiVersion = ConstantsExtension.TeamsApiVersion;
 

--- a/src/LobAccelerator.Library/Managers/TokenManagerHttpMessageHandler.cs
+++ b/src/LobAccelerator.Library/Managers/TokenManagerHttpMessageHandler.cs
@@ -18,8 +18,8 @@ namespace LobAccelerator.Library.Managers
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var scopes = request.Headers.GetValues("X-TMScopes");
-            var authResult = await tokenManager.GetOnBehalfOfAccessTokenAsync(scopes, accessToken);
+            var scopes = request.Headers.GetValues("X-LOBScopes");
+            var authResult = await tokenManager.GetOnBehalfOfAccessTokenAsync(accessToken, scopes);
             if (authResult != null)
             {
                 request.Headers.Authorization =


### PR DESCRIPTION
… OneDriveManager.  Both managers use the same scopes.  In the manager classes, we should only add additional scopes needed and check to make sure scope is not already in DefaultHeaders...

- Changed header name to X-LOBScopes (more or a debug helper for me).
- Moved setting of header from TeamsManager, OneDriveManager to ServiceLocator (setting once for common HttpClient instance)
- Modified SharePointManager to set accessToken in constructor
- Reverted back to forcing accessToken value in TokenManager.GetOnBehalfOfAccessTokenAsync signature
- Removed ValidateToken test from TokenTests
